### PR TITLE
- Changed counter reset time to hours with default value 3. From testing

### DIFF
--- a/Installer.ps1
+++ b/Installer.ps1
@@ -26,5 +26,5 @@ if($installMssqlMonitor -eq "Yes")
 if($installRdpMonitor -eq "Yes" -or $installMssqlMonitor -eq "Yes")
 {
     Register-ScheduledTask -Xml (get-content "$PSScriptRoot\PS Login Monitor - Update Firewall Rules.xml" | out-string) -TaskName "PS Login Monitor - Update Firewall Rules" -Force
-    [System.Windows.MessageBox]::Show("Task registered", "Title", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
+    [System.Windows.MessageBox]::Show("Tasks registered", "Title", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
 }


### PR DESCRIPTION
  noticed some IPs were attempting logins at almost exactly 15 minute intervals.
  May add randomly generated offset to reset time in future release, for now
  longer time period appears to work fine.
- RDP login events are now filtered to by login types 3 and 10 that are relevant
  to RDP logins. More info here: https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/basic-audit-logon-events
- Spelling error in installer script.